### PR TITLE
Splash Screen and data binding added

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="11" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,12 +4,12 @@ plugins {
 
 android {
     namespace 'com.example.attendanceproject'
-    compileSdk 32
+    compileSdk 33
 
     defaultConfig {
         applicationId "com.example.attendanceproject"
         minSdk 21
-        targetSdk 32
+        targetSdk 33
         versionCode 1
         versionName "1.0"
 
@@ -21,6 +21,10 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
+    }
+// databinding enanled here
+    dataBinding {
+        enabled = true
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,6 +14,13 @@
         tools:targetApi="31">
         <activity
             android:name=".MainActivity"
+            android:exported="false">
+            <meta-data
+                android:name="android.app.lib_name"
+                android:value="" />
+        </activity>
+        <activity
+            android:name=".ui.SplashActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/example/attendanceproject/Constant/Constant.java
+++ b/app/src/main/java/com/example/attendanceproject/Constant/Constant.java
@@ -1,0 +1,12 @@
+package com.example.attendanceproject.Constant;
+
+public class Constant {
+    /**
+     * delay in second
+     */
+    public static final int DELAY_SPLASH = 3000;
+    public static final int DELAY_FRAGMENT_PAUSE = 100;
+    public static final int DELAY_SCROLL_PAUSE = 300;
+    public static final int DELAY_API_REQUEST = 1000;
+    public static final int DELAY_MAP_MOVE = 2000;
+}

--- a/app/src/main/java/com/example/attendanceproject/ui/SplashActivity.java
+++ b/app/src/main/java/com/example/attendanceproject/ui/SplashActivity.java
@@ -1,0 +1,36 @@
+package com.example.attendanceproject.ui;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.databinding.DataBindingUtil;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.Handler;
+import android.provider.ContactsContract;
+
+import com.example.attendanceproject.Constant.Constant;
+import com.example.attendanceproject.MainActivity;
+import com.example.attendanceproject.R;
+import com.example.attendanceproject.databinding.ActivitySplashBinding;
+
+public class SplashActivity extends AppCompatActivity {
+    private ActivitySplashBinding layoutBinding;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        layoutBinding = DataBindingUtil.setContentView(this, R.layout.activity_splash);
+        getSupportActionBar().hide();
+
+        /**
+         * Handler for delay splash screen
+         */
+        new Handler().postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                    Intent intent = new Intent(SplashActivity.this, MainActivity.class);
+                    startActivity(intent);
+            }
+        }, Constant.DELAY_SPLASH);
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"

--- a/app/src/main/res/layout/activity_splash.xml
+++ b/app/src/main/res/layout/activity_splash.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:id="@+id/view_root"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/white"
+        android:fitsSystemWindows="true">
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="397dp"
+            android:layout_gravity="center"
+            android:gravity="center"
+            android:orientation="vertical">
+<!--            Change with logo or app name here-->
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="30sp"
+                android:text="Splash Screen"
+                android:textStyle="bold"/>
+        </LinearLayout>
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+</layout>


### PR DESCRIPTION
>Why use a splash screen

If we are assuming this is an attendance project and in normals, any app is used to first show the app logo and app name.
For developers, it's very useful to see the logic of any app because every app starts with a **splash screen>Login screen>MainScreen**
This is what normal apps follow the logic and to debug any project used a splash screen.

Thank you.
Kindly accept PR(Pull request) and merged to the main branch.